### PR TITLE
Feature: supporting OneDrive CN

### DIFF
--- a/src/auth/onedrive.js
+++ b/src/auth/onedrive.js
@@ -16,7 +16,8 @@ export async function getAccessToken() {
   }
 
   // Need refreshing, fetch new access token from Microsoft OneDrive API
-  const resp = await fetch('https://login.microsoftonline.com/common/oauth2/v2.0/token', {
+  // > add CN API option bellow, activate this at `src/auth/onedrive.js` 
+  const resp = await fetch(config.useOnedriveCN && 'https://login.chinacloudapi.cn/common/oauth2/v2.0/token' || 'https://login.microsoftonline.com/common/oauth2/v2.0/token', {
     method: 'POST',
     body: `client_id=${config.client_id}&redirect_uri=${config.redirect_uri}&client_secret=${config.client_secret}
     &refresh_token=${config.refresh_token}&grant_type=refresh_token`,

--- a/src/auth/onedrive.js
+++ b/src/auth/onedrive.js
@@ -16,8 +16,12 @@ export async function getAccessToken() {
   }
 
   // Need refreshing, fetch new access token from Microsoft OneDrive API
-  // > add CN API option bellow, activate this at `src/auth/onedrive.js` 
-  const resp = await fetch(config.useOnedriveCN && 'https://login.chinacloudapi.cn/common/oauth2/v2.0/token' || 'https://login.microsoftonline.com/common/oauth2/v2.0/token', {
+  // > add CN API option bellow, activate this at `src/auth/onedrive.js`
+  const oneDriveAuthEndpoint = config.useOneDriveCN
+    ? 'https://login.chinacloudapi.cn/common/oauth2/v2.0/token'
+    : 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+
+  const resp = await fetch(oneDriveAuthEndpoint, {
     method: 'POST',
     body: `client_id=${config.client_id}&redirect_uri=${config.redirect_uri}&client_secret=${config.client_secret}
     &refresh_token=${config.refresh_token}&grant_type=refresh_token`,

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -23,7 +23,6 @@ const config = {
    * Feature: add OneDriveCN (21Vianet) support
    * Usage: simply change `useOneDriveCN` to true
    */
-
   useOneDriveCN: false,
 
   /**

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -67,7 +67,14 @@ const config = {
    * Example: https://storage.spencerwoo.com/🥟%20Some%20test%20files/Previews/eb37c02438f.png?raw=true&proxied
    * You can also embed this link (url encoded) directly inside Markdown or HTML.
    */
-  proxyDownload: true
+  proxyDownload: true,
+
+  /**
+   * Feature: add CN(21Vianet) support
+   * Usage: simply uncomment the **useOnedriveCN: true** line
+   */
+
+  // useOnedriveCN: true 
 }
 
 export default config

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -20,6 +20,13 @@ const config = {
   firebase_url: 'https://onedrive-cf-refresh-token.firebaseio.com/auth.json',
 
   /**
+   * Feature: add OneDriveCN (21Vianet) support
+   * Usage: simply change `useOneDriveCN` to true
+   */
+
+  useOneDriveCN: false,
+
+  /**
    * Feature Caching
    * Enable Cloudflare cache for path pattern listed below.
    * Cache rules:
@@ -67,14 +74,7 @@ const config = {
    * Example: https://storage.spencerwoo.com/🥟%20Some%20test%20files/Previews/eb37c02438f.png?raw=true&proxied
    * You can also embed this link (url encoded) directly inside Markdown or HTML.
    */
-  proxyDownload: true,
-
-  /**
-   * Feature: add CN(21Vianet) support
-   * Usage: simply uncomment the **useOnedriveCN: true** line
-   */
-
-  // useOnedriveCN: true 
+  proxyDownload: true
 }
 
 export default config

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,10 @@ async function handleRequest(request) {
   const thumbnail = config.thumbnail ? searchParams.get('thumbnail') : false
   const proxied = config.proxyDownload ? searchParams.get('proxied') !== null : false
 
+  const isUseCnUrl = config.useOnedriveCN && 'microsoftgraph.chinacloudapi.cn' || 'graph.microsoft.com'
+
   if (thumbnail) {
-    const url = `https://graph.microsoft.com/v1.0/me/drive/root:${base +
+    const url = `https://${ isUseCnUrl }/v1.0/me/drive/root:${base +
       (pathname === '/' ? '' : pathname)}:/thumbnails/0/${thumbnail}/content`
     const resp = await fetch(url, {
       headers: {
@@ -68,7 +70,7 @@ async function handleRequest(request) {
     })
   }
 
-  const url = `https://graph.microsoft.com/v1.0/me/drive/root${wrapPathName(
+  const url = `https://${ isUseCnUrl }/v1.0/me/drive/root${wrapPathName(
     pathname
   )}?select=name,eTag,size,id,folder,file,image,%40microsoft.graph.downloadUrl&expand=children`
   const resp = await fetch(url, {

--- a/src/index.js
+++ b/src/index.js
@@ -54,10 +54,10 @@ async function handleRequest(request) {
   const thumbnail = config.thumbnail ? searchParams.get('thumbnail') : false
   const proxied = config.proxyDownload ? searchParams.get('proxied') !== null : false
 
-  const isUseCnUrl = config.useOnedriveCN && 'microsoftgraph.chinacloudapi.cn' || 'graph.microsoft.com'
+  const oneDriveApiEndpoint = config.useOneDriveCN ? 'microsoftgraph.chinacloudapi.cn' : 'graph.microsoft.com'
 
   if (thumbnail) {
-    const url = `https://${ isUseCnUrl }/v1.0/me/drive/root:${base +
+    const url = `https://${oneDriveApiEndpoint}/v1.0/me/drive/root:${base +
       (pathname === '/' ? '' : pathname)}:/thumbnails/0/${thumbnail}/content`
     const resp = await fetch(url, {
       headers: {
@@ -70,7 +70,7 @@ async function handleRequest(request) {
     })
   }
 
-  const url = `https://${ isUseCnUrl }/v1.0/me/drive/root${wrapPathName(
+  const url = `https://${oneDriveApiEndpoint}/v1.0/me/drive/root${wrapPathName(
     pathname
   )}?select=name,eTag,size,id,folder,file,image,%40microsoft.graph.downloadUrl&expand=children`
   const resp = await fetch(url, {


### PR DESCRIPTION
Add OneDrive CN( 21vianet ) supporting，also made it configurable using `src/config/default.js` . Nevertheless, it's a little bit tricky to get `refresh_token`，so i wrote a tutorial at my *master branch*

**About `redirect_uri`**:  I'm not using the website to get `refresh_token` , so the `redirect_uri` is  irrelevant，no need to modify it.
**Note**：changed 2 logic statements for using OneDrive CN Api.
**Default**：commented , You need to uncommet to Using it.