### PR TITLE
fix: #23 child items limit

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -26,7 +26,7 @@ const config = {
   useOneDriveCN: false,
 
   /**
-   * Feature: Pagination when a floder has multiple(>${top}) files
+   * Feature: Pagination when a folder has multiple(>${top}) files
    * - top: specify the page size limit of the result set, a big `top` value will slow down the fetching speed
    */
   pagination: {

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -27,12 +27,11 @@ const config = {
 
   /**
    * Feature: Pagination when a floder has multiple(>${top}) files
-   * - enable: toggle this feature on by assign true to `enable`
    * - top: specify the page size limit of the result set, a big `top` value will slow down the fetching speed
    */
   pagination: {
     enable: true,
-    top: 333 // default: 200, accepts a minimum value of 1 and a maximum value of 999 (inclusive)
+    top: 100 // default: 200, accepts a minimum value of 1 and a maximum value of 999 (inclusive)
   },
 
   /**

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -26,6 +26,16 @@ const config = {
   useOneDriveCN: false,
 
   /**
+   * Feature: Pagination when a floder has multiple(>${top}) files
+   * - enable: toggle this feature on by assign true to `enable`
+   * - top: specify the page size limit of the result set, a big `top` value will slow down the fetching speed
+   */
+  pagination: {
+    enable: true,
+    top: 333 // default: 200, accepts a minimum value of 1 and a maximum value of 999 (inclusive)
+  },
+
+  /**
    * Feature Caching
    * Enable Cloudflare cache for path pattern listed below.
    * Cache rules:

--- a/src/folderView.js
+++ b/src/folderView.js
@@ -33,7 +33,7 @@ function readableFileSize(bytes, si) {
  * @param {*} items
  * @param {*} isIndex don't show ".." on index page.
  */
-export async function renderFolderView(items, path) {
+export async function renderFolderView(items, path, request) {
   const isIndex = path === '/'
 
   const el = (tag, attrs, content) => `<${tag} ${attrs.join(' ')}>${content}</${tag}>`
@@ -119,5 +119,5 @@ export async function renderFolderView(items, path) {
       (readmeExists && !isIndex ? await renderMarkdown(readmeFetchUrl, 'fade-in-fwd', '') : '') +
       (isIndex ? intro : '')
   )
-  return renderHTML(body)
+  return renderHTML(body, ...[request.pLink, request.pIdx])
 }

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ async function handleRequest(request) {
   const accessToken = await getAccessToken()
 
   const { pathname, searchParams } = new URL(request.url)
-  const neopathname = pathname.replace(/pagination$/, '')
+  const neoPathname = pathname.replace(/pagination$/, '')
 
   const rawImage = searchParams.get('raw')
   const thumbnail = config.thumbnail ? searchParams.get('thumbnail') : false
@@ -73,7 +73,7 @@ async function handleRequest(request) {
 
   const isRequestFolder = pathname.endsWith('/') || searchParams.get('page')
   const childrenApi =
-    `https://${oneDriveApiEndpoint}/v1.0/me/drive/root${wrapPathName(neopathname.replace(/\/$/, ''))}:/children` +
+    `https://${oneDriveApiEndpoint}/v1.0/me/drive/root${wrapPathName(neoPathname.replace(/\/$/, ''))}:/children` +
     (config.pagination.enable && config.pagination.top ? `?$top=${config.pagination.top}` : ``)
   // using different api to handle file or folder: children or driveItem
   let url = isRequestFolder ? childrenApi : `https://${oneDriveApiEndpoint}/v1.0/me/drive/root${wrapPathName(pathname)}`
@@ -126,7 +126,7 @@ async function handleRequest(request) {
         const filename = searchParams.get('upload')
         const key = searchParams.get('key')
         if (filename && key && config.upload.key === key) {
-          return await handleUpload(request, neopathname, filename)
+          return await handleUpload(request, neoPathname, filename)
         } else {
           return new Response('', {
             status: 400
@@ -139,7 +139,7 @@ async function handleRequest(request) {
         return Response.redirect(request.url + '/', 302)
       }
 
-      return new Response(await renderFolderView(data.value, neopathname, request), {
+      return new Response(await renderFolderView(data.value, neoPathname, request), {
         headers: {
           'Access-Control-Allow-Origin': '*',
           'content-type': 'text/html'

--- a/src/render/htmlWrapper.js
+++ b/src/render/htmlWrapper.js
@@ -1,6 +1,6 @@
 import { favicon } from './favicon'
 
-const COMMIT_HASH = '89afde99425f90047d6cde015bb90ab7d5b64b2f'
+const COMMIT_HASH = '5d7579fcfb4729fcb855110c5f0ed5488d1d0d44'
 
 const pagination = (pIdx, attrs) => {
   const getAttrs = (c, h, isNext) =>
@@ -18,7 +18,7 @@ const pagination = (pIdx, attrs) => {
       default:
         attrs = [getAttrs('pre', pIdx - 1, 0), getAttrs('next', pIdx + 1, 1)]
     }
-    return `${`<a ${attrs[0]}><i class="fas fa-arrow-left"></i></a>`} &nbsp;${`<a ${attrs[1]}><i class="fas fa-arrow-right"></i></a>`}`
+    return `${`<a ${attrs[0]}><i class="fas fa-angle-left" style="font-size: 8px;"></i> PREV</a>`}<span>Page ${pIdx}</span> ${`<a ${attrs[1]}>NEXT <i class="fas fa-angle-right" style="font-size: 8px;"></i></a>`}`
   }
   return ''
 }
@@ -43,12 +43,11 @@ export function renderHTML(body, pLink, pIdx) {
       <script src="https://cdn.jsdelivr.net/npm/prismjs@1.17.1/plugins/autoloader/prism-autoloader.min.js"></script>
       <script src="https://cdn.jsdelivr.net/npm/medium-zoom@1.0.6/dist/medium-zoom.min.js"></script>
       <script src="https://cdn.jsdelivr.net/npm/turbolinks@5.2.0/dist/turbolinks.min.js"></script>
-      <style>.paginate-container a.off {pointer-events: none;opacity: 0.5;}</style>
     </head>
     <body>
       <nav id="navbar" data-turbolinks-permanent><div class="brand">📁 Spencer's OneDrive Index</div></nav>
       ${body}
-      <div class='paginate-container' style="margin-top: 0.5em">${pagination(pIdx)}</div>
+      <div class="paginate-container">${pagination(pIdx)}</div>
       <div id="flex-container" data-turbolinks-permanent style="flex-grow: 1;"></div>
       <footer id="footer" data-turbolinks-permanent><p>Powered by <a href="https://github.com/spencerwooo/onedrive-cf-index">onedrive-cf-index</a>, hosted on <a href="https://www.cloudflare.com/products/cloudflare-workers/">Cloudflare Workers</a>.</p></footer>
       <script>

--- a/src/render/htmlWrapper.js
+++ b/src/render/htmlWrapper.js
@@ -2,7 +2,31 @@ import { favicon } from './favicon'
 
 const COMMIT_HASH = '89afde99425f90047d6cde015bb90ab7d5b64b2f'
 
-export function renderHTML(body) {
+const pagination = (pIdx, attrs) => {
+  const getAttrs = (c, h, isNext) =>
+    `class="${c}" ${h ? `href="pagination?page=${h}"` : ''} ${
+      isNext === undefined ? '' : `onclick="handlePagination(${isNext})"`
+    }`
+  if (pIdx) {
+    switch (pIdx) {
+      case pIdx < 0 ? pIdx : null:
+        attrs = [getAttrs('pre', -pIdx - 1, 0), getAttrs('next off', null)]
+        break
+      case 1:
+        attrs = [getAttrs('pre off', null), getAttrs('next', pIdx + 1, 1)]
+        break
+      default:
+        attrs = [getAttrs('pre', pIdx - 1, 0), getAttrs('next', pIdx + 1, 1)]
+    }
+    return `${`<a ${attrs[0]}><i class="fas fa-arrow-left"></i></a>`} &nbsp;${`<a ${attrs[1]}><i class="fas fa-arrow-right"></i></a>`}`
+  }
+  return ''
+}
+
+export function renderHTML(body, pLink, pIdx) {
+  pLink = pLink ? pLink : ''
+  const p = 'window[pLinkId]'
+
   return `<!DOCTYPE html>
   <html lang="en">
     <head>
@@ -19,19 +43,41 @@ export function renderHTML(body) {
       <script src="https://cdn.jsdelivr.net/npm/prismjs@1.17.1/plugins/autoloader/prism-autoloader.min.js"></script>
       <script src="https://cdn.jsdelivr.net/npm/medium-zoom@1.0.6/dist/medium-zoom.min.js"></script>
       <script src="https://cdn.jsdelivr.net/npm/turbolinks@5.2.0/dist/turbolinks.min.js"></script>
+      <style>.paginate-container a.off {pointer-events: none;opacity: 0.5;}</style>
     </head>
     <body>
       <nav id="navbar" data-turbolinks-permanent><div class="brand">📁 Spencer's OneDrive Index</div></nav>
       ${body}
+      <div class='paginate-container' style="margin-top: 0.5em">${pagination(pIdx)}</div>
       <div id="flex-container" data-turbolinks-permanent style="flex-grow: 1;"></div>
       <footer id="footer" data-turbolinks-permanent><p>Powered by <a href="https://github.com/spencerwooo/onedrive-cf-index">onedrive-cf-index</a>, hosted on <a href="https://www.cloudflare.com/products/cloudflare-workers/">Cloudflare Workers</a>.</p></footer>
       <script>
         if (typeof ap !== "undefined" && ap.paused !== true) {
           ap.pause()
         }
-        Turbolinks.start()
         Prism.highlightAll()
         mediumZoom('[data-zoomable]')
+        if ('${pLink}') {
+          if (!window.pLinkId) history.pushState(history.state, '', location.pathname.replace('pagination', ''))
+          if (location.pathname.endsWith('/')) {
+            pLinkId = history.state.turbolinks.restorationIdentifier
+            ${p} = [['${pLink}'], 1]
+          }
+          if (${p}[0].length < ${p}[1]) (${p} = [[...${p}[0], '${pLink}'], ${p}[1]])
+        }
+        function handlePagination(isNext) {
+          isNext ? ${p}[1]++ : ${p}[1]--
+          addEventListener(
+            'turbolinks:request-start',
+            event => {
+              const xhr = event.data.xhr
+              xhr.setRequestHeader('pLink', ${p}[0][${p}[1] -2])
+              xhr.setRequestHeader('pIdx', ${p}[1] + '')
+            },
+            { once: true }
+          )
+        }
+        Turbolinks.start()
       </script>
     </body>
   </html>`

--- a/src/render/pathUtil.js
+++ b/src/render/pathUtil.js
@@ -12,7 +12,7 @@ function getPathLink(pathItems, idx) {
   }
 
   pathList[0] = ''
-  return pathList.join('/')
+  return pathList.join('/') + '/'
 }
 
 /**

--- a/themes/spencer.css
+++ b/themes/spencer.css
@@ -46,7 +46,8 @@ a {
   font-weight: bold;
 }
 
-.container {
+.container,
+.paginate-container {
   width: calc(100% - 40px);
   max-width: 800px;
   margin: 0 auto;
@@ -133,6 +134,22 @@ a.item:hover {
   text-align: center;
   margin: 3rem 0rem;
   opacity: 0.6;
+}
+
+.paginate-container {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+}
+
+.paginate-container a {
+  text-decoration: none;
+  color: #000;
+}
+
+.paginate-container a.off {
+  pointer-events: none;
+  opacity: 0.5;
 }
 
 .fade-in-bottom {

--- a/themes/spencer.css
+++ b/themes/spencer.css
@@ -98,6 +98,10 @@ footer {
   text-align: center;
 }
 
+footer a {
+  text-decoration: none;
+}
+
 a:hover,
 a.item:hover {
   opacity: 0.6;
@@ -144,7 +148,6 @@ a.item:hover {
 
 .paginate-container a {
   text-decoration: none;
-  color: #000;
 }
 
 .paginate-container a.off {


### PR DESCRIPTION

使用 children api 的翻页请求，一次性加载所有文件（使用touch wildcard创建1000个文件测试过，成功索引，测试地址: drive.tcxz.cc/test）

缺点：
- 多文件请求多次，比较慢；
- 严格来说浪费了后面第一次 chlidren 请求的返回结果（就比原本请求多了一个@odata.nextLink）

**望作者大大测试和完善**🐒 :  深夜PR (逃~~~
