### PR TITLE
Use emoji instead of folder icon when possible

### DIFF
--- a/src/files/load.js
+++ b/src/files/load.js
@@ -82,7 +82,7 @@ export async function handleFile(request, pathname, downloadUrl, { proxied = fal
 }
 
 export async function handleUpload(request, pathname, filename) {
-  const url = `https://graph.microsoft.com/v1.0/me/drive/root:${encodeURIComponent(config.base) +
+  const url = `https://graph.microsoft.com/v1.0/me/drive/root:${config.base +
     (pathname.slice(-1) === '/' ? pathname : pathname + '/')}${filename}:/content`
   return await fetch(url, {
     method: 'PUT',

--- a/src/folderView.js
+++ b/src/folderView.js
@@ -71,7 +71,6 @@ export async function renderFolderView(items, path) {
               .map(i => {
                 // Check if the current item is a folder or a file
                 if ('folder' in i) {
-                  // TODO: Check folder has an emoji
                   // const emojiRegex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/g
                   const charRegex = /\w|\s/
                   const firstNonEmojiPosition = i.name.search(charRegex)

--- a/src/folderView.js
+++ b/src/folderView.js
@@ -38,11 +38,11 @@ export async function renderFolderView(items, path) {
 
   const el = (tag, attrs, content) => `<${tag} ${attrs.join(' ')}>${content}</${tag}>`
   const div = (className, content) => el('div', [`class=${className}`], content)
-  const item = (icon, fileName, fileAbsoluteUrl, size) =>
+  const item = (icon, fileName, fileAbsoluteUrl, size, emojiIcon) =>
     el(
       'a',
       [`href="${fileAbsoluteUrl}"`, 'class="item"', size ? `size="${size}"` : ''],
-      el('i', [`class="${icon}"`], '') +
+      (emojiIcon ? el('i', ['class="emoji"'], emojiIcon) : el('i', [`class="${icon}"`], '')) +
         fileName +
         el('div', ['style="flex-grow: 1;"'], '') +
         (fileName === '..' ? '' : el('span', ['class="size"'], readableFileSize(size)))
@@ -69,7 +69,16 @@ export async function renderFolderView(items, path) {
           (!isIndex ? item('far fa-folder', '..', `${path}..`) : '') +
             items
               .map(i => {
+                // Check if the current item is a folder or a file
                 if ('folder' in i) {
+                  // const emojiRegex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/g
+                  const charRegex = /\w|\s/
+                  const firstNonEmojiPosition = i.name.search(charRegex)
+                  if (firstNonEmojiPosition !== 0) {
+                    const headerEmojiStr = i.name.slice(0, firstNonEmojiPosition)
+                    const folderName = i.name.slice(firstNonEmojiPosition).trim()
+                    return item('', folderName, `${path}${i.name}/`, i.size, headerEmojiStr)
+                  }
                   return item('far fa-folder', i.name, `${path}${i.name}/`, i.size)
                 } else if ('file' in i) {
                   // Check if README.md exists

--- a/src/folderView.js
+++ b/src/folderView.js
@@ -42,7 +42,7 @@ export async function renderFolderView(items, path) {
     el(
       'a',
       [`href="${fileAbsoluteUrl}"`, 'class="item"', size ? `size="${size}"` : ''],
-      (emojiIcon ? el('i', ['class="emoji"'], emojiIcon) : el('i', [`class="${icon}"`], '')) +
+      (emojiIcon ? el('i', ['style="font-style: normal"'], emojiIcon) : el('i', [`class="${icon}"`], '')) +
         fileName +
         el('div', ['style="flex-grow: 1;"'], '') +
         (fileName === '..' ? '' : el('span', ['class="size"'], readableFileSize(size)))
@@ -71,12 +71,17 @@ export async function renderFolderView(items, path) {
               .map(i => {
                 // Check if the current item is a folder or a file
                 if ('folder' in i) {
+                  // TODO: Check folder has an emoji
                   // const emojiRegex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/g
                   const charRegex = /\w|\s/
                   const firstNonEmojiPosition = i.name.search(charRegex)
                   if (firstNonEmojiPosition !== 0) {
-                    const headerEmojiStr = i.name.slice(0, firstNonEmojiPosition)
-                    const folderName = i.name.slice(firstNonEmojiPosition).trim()
+                    let headerEmojiStr = i.name.slice(0, firstNonEmojiPosition)
+                    let folderName = i.name.slice(firstNonEmojiPosition).trim()
+                    if (firstNonEmojiPosition === -1) {
+                      headerEmojiStr = i.name
+                      folderName = ''
+                    }
                     return item('', folderName, `${path}${i.name}/`, i.size, headerEmojiStr)
                   }
                   return item('far fa-folder', i.name, `${path}${i.name}/`, i.size)

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const cache = caches.default
  * @param {string} pathname The absolute path to file
  */
 function wrapPathName(pathname) {
-  pathname = encodeURIComponent(config.base) + (pathname === '/' ? '' : pathname)
+  pathname = config.base + (pathname === '/' ? '' : pathname)
   return pathname === '/' || pathname === '' ? '' : ':' + pathname
 }
 
@@ -45,7 +45,7 @@ async function handleRequest(request) {
     if (maybeResponse) return maybeResponse
   }
 
-  const base = encodeURIComponent(config.base)
+  const base = config.base
   const accessToken = await getAccessToken()
 
   const { pathname, searchParams } = new URL(request.url)


### PR DESCRIPTION
Hi,

This PR is intend to use emoji as the folder icon instead of regular folder icon when possible.

When there's an emoji at the beginning of the folder name, it will be used as the folder icon, The space between Alphabetical Letter and Emoji (if it exists) will be trimmed.

This PR didn't consider the situation when there are multiple emojis at the beginning of the folder name, since some emojis are concatenated by couple of emojis, see the edge cases in screenshot below.

Screenshot:
<img width="1149" alt="Screen Shot 2020-09-22 at 13 07 53" src="https://user-images.githubusercontent.com/10571717/93845779-b3ead780-fcd4-11ea-89bc-920d24e63dec.png">
