### PR TITLE
fix: reimplement emoji checking logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prettier": "^1.18.2"
   },
   "dependencies": {
+    "emoji-regex": "^9.2.0",
     "font-awesome-filetypes": "^2.1.0",
     "marked": "^1.1.1"
   }

--- a/src/folderView.js
+++ b/src/folderView.js
@@ -1,4 +1,5 @@
 import { getClassNameForMimeType, getClassNameForFilename } from 'font-awesome-filetypes'
+const emojiRegex = require('emoji-regex/RGI_Emoji.js');
 
 import { renderHTML } from './render/htmlWrapper'
 import { renderPath } from './render/pathUtil'
@@ -71,19 +72,12 @@ export async function renderFolderView(items, path, request) {
               .map(i => {
                 // Check if the current item is a folder or a file
                 if ('folder' in i) {
-                  // const emojiRegex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/g
-                  const charRegex = /\w|\s/
-                  const firstNonEmojiPosition = i.name.search(charRegex)
-                  if (firstNonEmojiPosition !== 0) {
-                    let headerEmojiStr = i.name.slice(0, firstNonEmojiPosition)
-                    let folderName = i.name.slice(firstNonEmojiPosition).trim()
-                    if (firstNonEmojiPosition === -1) {
-                      headerEmojiStr = i.name
-                      folderName = ''
-                    }
-                    return item('', folderName, `${path}${i.name}/`, i.size, headerEmojiStr)
+                  let emoji = emojiRegex().exec(i.name)
+                  if (emoji && !emoji.index) {
+                    return item('', i.name.replace(emoji, '').trim(), `${path}${i.name}/`, i.size, emoji[0])
+                  } else {
+                    return item('far fa-folder', i.name, `${path}${i.name}/`, i.size)
                   }
-                  return item('far fa-folder', i.name, `${path}${i.name}/`, i.size)
                 } else if ('file' in i) {
                   // Check if README.md exists
                   if (!readmeExists) {

--- a/src/folderView.js
+++ b/src/folderView.js
@@ -1,5 +1,5 @@
+import emojiRegex from 'emoji-regex/RGI_Emoji'
 import { getClassNameForMimeType, getClassNameForFilename } from 'font-awesome-filetypes'
-const emojiRegex = require('emoji-regex/RGI_Emoji.js');
 
 import { renderHTML } from './render/htmlWrapper'
 import { renderPath } from './render/pathUtil'

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,6 +236,11 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
+emoji-regex@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.0.tgz#a26da8e832b16a9753309f25e35e3c0efb9a066a"
+  integrity sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==
+
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"


### PR DESCRIPTION
### Fixing
- fixes #37 which breaks non-ascii folder name.
### Breaking
- Only one (or multiple emoji combined with ZWJ) emoji should be matched.
- Newest emoji like Unicode 14 or later is not currently supported, but soon.
### Demo
![image](https://user-images.githubusercontent.com/9512067/98061730-7c507d00-1e87-11eb-9cc1-65f079918df8.png)
![image](https://user-images.githubusercontent.com/9512067/98061914-f3861100-1e87-11eb-8d44-86bd8c21643b.png)

