### PR TITLE
perf: using $select param to improve request performance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ async function handleRequest(request) {
   const proxied = config.proxyDownload ? searchParams.get('proxied') !== null : false
 
   if (thumbnail) {
-    const url = `${config.nationalApi.graph}/v1.0/me/drive/root${wrapPathName(
+    const url = `${config.apiEndpoint.graph}/v1.0/me/drive/root${wrapPathName(
       neoPathname,
       isRequestFolder
     )}:/thumbnails/0/${thumbnail}/content`
@@ -78,7 +78,7 @@ async function handleRequest(request) {
     })
   }
 
-  let url = `${config.nationalApi.graph}/v1.0/me/drive/root${wrapPathName(neoPathname, isRequestFolder)}${
+  let url = `${config.apiEndpoint.graph}/v1.0/me/drive/root${wrapPathName(neoPathname, isRequestFolder)}${
     isRequestFolder
       ? '/children?$select=name,size,folder,file'
       : '?select=%40microsoft.graph.downloadUrl,name,size,file'

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,9 @@ async function handleRequest(request) {
   }
 
   let url = `${config.nationalApi.graph}/v1.0/me/drive/root${wrapPathName(neoPathname, isRequestFolder)}${
-    isRequestFolder ? '/children' : ''
+    isRequestFolder
+      ? '/children?$select=name,size,folder,file'
+      : '?select=%40microsoft.graph.downloadUrl,name,size,file'
   }${isRequestFolder && config.pagination.enable && config.pagination.top ? `&$top=${config.pagination.top}` : ''}`
 
   // get & set {pLink ,pIdx} for fetching and paging

--- a/src/render/htmlWrapper.js
+++ b/src/render/htmlWrapper.js
@@ -5,7 +5,7 @@ const COMMIT_HASH = '88570208bdd3dc88ab2e13bbf7de370b3b8dba38'
 const pagination = (pIdx, attrs) => {
   const getAttrs = (c, h, isNext) =>
     `class="${c}" ${h ? `href="pagination?page=${h}"` : ''} ${
-      isNext === undefined ? '' : `onclick="handlePagination(${isNext})"`
+      isNext === undefined ? '' : `id=${c.includes('pre') ? 'pagination-pre' : 'pagination-next'}`
     }`
   if (pIdx) {
     switch (pIdx) {

--- a/src/render/htmlWrapper.js
+++ b/src/render/htmlWrapper.js
@@ -24,7 +24,6 @@ const pagination = (pIdx, attrs) => {
 }
 
 export function renderHTML(body, pLink, pIdx) {
-  pLink = pLink || ''
   const p = 'window[pLinkId]'
 
   return `<!DOCTYPE html>

--- a/themes/spencer.css
+++ b/themes/spencer.css
@@ -143,6 +143,7 @@ a.item:hover {
 .paginate-container {
   margin-top: 1.5rem;
   display: grid;
+  justify-content: space-between;
   grid-template-columns: repeat(3, auto);
 }
 


### PR DESCRIPTION
这会使得返回的数据更少，加快请求速度：

before: 
![before](https://user-images.githubusercontent.com/63141491/104150053-97091a00-5413-11eb-9385-1c61c544e930.png)

after: 
![after](https://user-images.githubusercontent.com/63141491/104150072-a12b1880-5413-11eb-8b3a-60d80035150c.png)

外加修复了两个 bug ( thumbnail 和 pagination)