### PR TITLE
Use thumbnails to preview images

### DIFF
--- a/src/fileView.js
+++ b/src/fileView.js
@@ -111,8 +111,16 @@ function renderPDFPreview(file) {
  * @param {Object} file Object representing the image to preview
  */
 function renderImage(file) {
+  let downurl = file['@microsoft.graph.downloadUrl'];
+  if (downurl.includes('?')) {
+    const urlSplitParams = downurl.split('?')
+    const param = new URLSearchParams(urlSplitParams[1])
+    param.delete('raw')
+    param.append('thumbnail','largeSquare')
+    downurl = urlSplitParams[0] + '?' + param.toString()
+  }
   return `<div class="image-wrapper">
-            <img data-zoomable src="${file['@microsoft.graph.downloadUrl']}" alt="${file.name}" style="width: 100%; height: auto; position: relative;"></img>
+            <img data-zoomable src="${downurl}" alt="${file.name}" style="width: 100%; height: auto; position: relative;"></img>
           </div>`
 }
 

--- a/src/fileView.js
+++ b/src/fileView.js
@@ -116,7 +116,7 @@ function renderImage(file) {
     const urlSplitParams = downurl.split('?')
     const param = new URLSearchParams(urlSplitParams[1])
     param.delete('raw')
-    param.append('thumbnail','largeSquare')
+    param.append('thumbnail','large')
     downurl = urlSplitParams[0] + '?' + param.toString()
   }
   return `<div class="image-wrapper">


### PR DESCRIPTION
https://github.com/spencerwooo/onedrive-cf-index/blob/21e1f4a0b5a24a1df49c1fb42941787a995cdb6c/src/fileView.js#L113-L117

```
function renderImage(file) {
  let downurl = file['@microsoft.graph.downloadUrl'];
  if (downurl.includes('?')) {
    const urlSplitParams = downurl.split('?')
    const param = new URLSearchParams(urlSplitParams[1])
    param.delete('raw')
    param.append('thumbnail','largeSquare')
    downurl = urlSplitParams[0] + '?' + param.toString()
  }
  return `<div class="image-wrapper">
            <img data-zoomable src="${downurl}" alt="${file.name}" style="width: 100%; height: auto; position: relative;"></img>
          </div>`
}
```
国内访问OneDrive速度捉急，预览太慢，改用缩略图预览

小改一下
~代码粗略，见谅。~ 其实是从`mdRenderer.js`扣的