### PR TITLE
Disable Turbolinks on links that which do not need to be previewed to prevent binary files being opened as html

### DIFF
--- a/src/folderView.js
+++ b/src/folderView.js
@@ -115,6 +115,11 @@ export async function renderFolderView(items, path, request) {
               } else {
                 fileIcon = `far ${fileIcon}`
               }
+
+              const fileExt = i.name
+              .split('.')
+              .pop()
+              .toLowerCase()
               
               if (!(fileExt in extensions)) {
                 return item_no_trobulink(fileIcon, i.name, `${path}${i.name}`, i.size)

--- a/src/folderView.js
+++ b/src/folderView.js
@@ -4,6 +4,7 @@ import { getClassNameForMimeType, getClassNameForFilename } from 'font-awesome-f
 import { renderHTML } from './render/htmlWrapper'
 import { renderPath } from './render/pathUtil'
 import { renderMarkdown } from './render/mdRenderer'
+import { extensions } from './render/fileExtension'
 
 /**
  * Convert bytes to human readable file size
@@ -43,6 +44,15 @@ export async function renderFolderView(items, path, request) {
     el(
       'a',
       [`href="${fileAbsoluteUrl}"`, 'class="item"', size ? `size="${size}"` : ''],
+      (emojiIcon ? el('i', ['style="font-style: normal"'], emojiIcon) : el('i', [`class="${icon}"`], '')) +
+      fileName +
+      el('div', ['style="flex-grow: 1;"'], '') +
+      (fileName === '..' ? '' : el('span', ['class="size"'], readableFileSize(size)))
+    )
+    const item_no_trobulink = (icon, fileName, fileAbsoluteUrl, size, emojiIcon) =>
+    el(
+      'a',
+      [`href="${fileAbsoluteUrl}"`, 'data-turbolinks="false"', 'class="item"', size ? `size="${size}"` : ''],
       (emojiIcon ? el('i', ['style="font-style: normal"'], emojiIcon) : el('i', [`class="${icon}"`], '')) +
       fileName +
       el('div', ['style="flex-grow: 1;"'], '') +
@@ -105,7 +115,12 @@ export async function renderFolderView(items, path, request) {
               } else {
                 fileIcon = `far ${fileIcon}`
               }
-              return item(fileIcon, i.name, `${path}${i.name}`, i.size)
+              
+              if (!(fileExt in extensions)) {
+                return item_no_trobulink(fileIcon, i.name, `${path}${i.name}`, i.size)
+              } else {
+                return item(fileIcon, i.name, `${path}${i.name}`, i.size)
+              }
             } else {
               console.log(`unknown item type ${i}`)
             }


### PR DESCRIPTION
**在无需预览的链接上禁用Turbolinks以防止二进制文件被作为html打开**

在让页面中的链接默认使用代理的情况下，Turbolinks将会使二进制文件在浏览器中以html的方式打开而不是直接下载